### PR TITLE
Properly install .chains subpackage.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='libnum',
       description='Some number theoretic functions.',
       long_description=libnum.__doc__,
 
-      packages=['libnum'],
+      packages=['libnum', 'libnum.chains'],
       provides=['libnum'],
 
       keywords='number prime gcd lcm modular invmod elliptic',


### PR DESCRIPTION
`setup.py` was incorrectly leaving out the `.chains` subpackage, leading to import errors in freshly installed packages.